### PR TITLE
fix(compose): убрать публикацию порта 5432 у ai-service-db

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,5 @@ services:
     container_name: ai-service-db
     restart: on-failure
     env_file: .env
-    ports:
-      - 5432:5432
     volumes:
       - ./.meta/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Конфликт хостового порта 5432 с auth-service-db. БД доступна внутри compose-сети по имени сервиса.