### PR TITLE
build(docker): multi-stage slim образ ai-service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
-FROM node:20
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-
-RUN npm i
+RUN npm ci
 
 COPY . .
-
 RUN npm run build
 
-CMD [ "npm", "run", "start:dev" ]
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+CMD ["node", "dist/main"]


### PR DESCRIPTION
Образ ~2 ГБ (полный node:20 + devDeps + start:dev) → multi-stage node:20-alpine, npm ci --omit=dev, node dist/main. Чинит флейки распаковки в containerd.