### PR TITLE
fix(docker): корректный entry dist/src/main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN npm ci --omit=dev
 
 COPY --from=builder /app/dist ./dist
 
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]


### PR DESCRIPTION
Сборка кладёт main.js в dist/src (из-за migrations/), а не dist/main.