### PR TITLE
build: плоский dist/main (исключить migrations из сборки)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN npm ci --omit=dev
 
 COPY --from=builder /app/dist ./dist
 
-CMD ["node", "dist/src/main"]
+CMD ["node", "dist/main"]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "migrations"]
 }


### PR DESCRIPTION
migrations/ поднимал корень компиляции → dist/src/main. Исключаем migrations из tsconfig.build → dist/main.js, как у остальных сервисов.